### PR TITLE
refactor: high-priority codebase cleanup (H1–H6)

### DIFF
--- a/api/_utils/chunk-processor.ts
+++ b/api/_utils/chunk-processor.ts
@@ -66,8 +66,8 @@ export async function processChunk(
             apiKey,
             model: job.config.model,
             language: job.config.language,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            ...((job.config as any) || {}),
+            prompt: job.config.prompt,
+            temperature: job.config.temperature,
           }),
         chunk.index // Priority based on chunk order
       );

--- a/api/_utils/resolve-api-key.ts
+++ b/api/_utils/resolve-api-key.ts
@@ -1,0 +1,68 @@
+import { supabaseAdmin } from '../_lib/supabase-admin';
+import { checkQuota } from '../_middleware/usage-tracking';
+
+export interface ResolvedApiKey {
+  apiKey: string;
+  shouldTrackQuota: boolean;
+  subscriptionTier: string;
+}
+
+export class FreeUserNoKeyError extends Error {
+  readonly requiresApiKey = true;
+  constructor() {
+    super('API key required');
+  }
+}
+
+export class QuotaExceededError extends Error {
+  constructor(
+    public readonly minutesRemaining: number,
+    public readonly minutesRequired?: number
+  ) {
+    super('Quota exceeded');
+  }
+}
+
+/**
+ * Resolves which OpenAI API key to use for a given request.
+ *
+ * BYOK users: returns their key with no quota deduction.
+ * Pro/Team users: returns the platform key and sets shouldTrackQuota = true.
+ * Free users without a key: throws FreeUserNoKeyError.
+ * Users over quota: throws QuotaExceededError.
+ */
+export async function resolveApiKey(
+  userId: string,
+  userKey: string | null,
+  estimatedMinutes: number,
+  callerLabel: string
+): Promise<ResolvedApiKey> {
+  if (userKey) {
+    console.log(`[${callerLabel}] User ${userId} using BYOK mode`);
+    return { apiKey: userKey, shouldTrackQuota: false, subscriptionTier: 'byok' };
+  }
+
+  const { data: subscription } = await supabaseAdmin
+    .from('subscriptions')
+    .select('tier')
+    .eq('user_id', userId)
+    .single();
+
+  if (!subscription || subscription.tier === 'free') {
+    throw new FreeUserNoKeyError();
+  }
+
+  const quotaCheck = await checkQuota(userId, estimatedMinutes);
+  if (!quotaCheck.allowed) {
+    throw new QuotaExceededError(quotaCheck.minutesRemaining, quotaCheck.minutesRequired);
+  }
+
+  console.log(
+    `[${callerLabel}] User ${userId} (${subscription.tier}) using platform key with quota tracking`
+  );
+  return {
+    apiKey: process.env.OPENAI_API_KEY!,
+    shouldTrackQuota: true,
+    subscriptionTier: subscription.tier,
+  };
+}

--- a/api/_utils/transcript-assembler.ts
+++ b/api/_utils/transcript-assembler.ts
@@ -78,43 +78,14 @@ async function removeOverlaps(chunks: ChunkMetadata[], transcripts: string[]): P
     const estimatedOverlapWords = Math.min(estimatedByDuration, maxOverlapWords);
     const overlapWords = previousWords.slice(-estimatedOverlapWords).join(' ');
 
-    // Find overlap in current transcript - try multiple strategies
+    // Find overlap in current transcript - try multiple strategies in priority order
     const currentWords = currentTranscript.split(/\s+/);
 
-    // Strategy 1: Try first 50% (expanded from 30%)
-    const searchWindowSize = Math.ceil(currentWords.length * 0.5);
-    const searchWindow = currentWords.slice(0, searchWindowSize).join(' ');
-
-    let matchPosition = findOverlapMatch(
-      overlapWords,
-      searchWindow,
-      0.7 // 70% similarity threshold
-    );
-
-    // Strategy 2: If not found, try full current transcript
-    if (matchPosition === -1) {
-      matchPosition = findOverlapMatch(overlapWords, currentTranscript, 0.7);
-    }
-
-    // Strategy 3: If still not found, try substring matching
-    if (matchPosition === -1) {
-      const overlapWordsArray = overlapWords.split(/\s+/);
-      const minMatchLength = Math.floor(overlapWordsArray.length * 0.6); // Match at least 60% of words
-
-      for (let startIdx = 0; startIdx < overlapWordsArray.length - minMatchLength + 1; startIdx++) {
-        const phraseToFind = overlapWordsArray.slice(startIdx, startIdx + minMatchLength).join(' ');
-        const lowerCurrentTranscript = currentTranscript.toLowerCase();
-        const index = lowerCurrentTranscript.indexOf(phraseToFind.toLowerCase());
-
-        if (index !== -1) {
-          // Convert character index to word index
-          const beforeMatch = lowerCurrentTranscript.substring(0, index);
-          const wordsBeforeMatch = beforeMatch.split(/\s+/).filter((w) => w.length > 0).length;
-          matchPosition = wordsBeforeMatch + minMatchLength;
-          break;
-        }
-      }
-    }
+    let matchPosition = findOverlapInSearchWindow(overlapWords, currentWords);
+    if (matchPosition === -1)
+      matchPosition = findOverlapInFullTranscript(overlapWords, currentTranscript);
+    if (matchPosition === -1)
+      matchPosition = findOverlapBySubstringMatch(overlapWords, currentTranscript);
 
     if (matchPosition !== -1) {
       // Found match, remove overlap from current transcript
@@ -139,6 +110,34 @@ async function removeOverlaps(chunks: ChunkMetadata[], transcripts: string[]): P
   // Join all deduplicated transcripts
   const assembled = deduplicatedTranscripts.join(' ');
   return normalizeSentences(assembled);
+}
+
+function findOverlapInSearchWindow(overlapWords: string, currentWords: string[]): number {
+  const windowSize = Math.ceil(currentWords.length * 0.5);
+  const searchWindow = currentWords.slice(0, windowSize).join(' ');
+  return findOverlapMatch(overlapWords, searchWindow, 0.7);
+}
+
+function findOverlapInFullTranscript(overlapWords: string, currentTranscript: string): number {
+  return findOverlapMatch(overlapWords, currentTranscript, 0.7);
+}
+
+function findOverlapBySubstringMatch(overlapWords: string, currentTranscript: string): number {
+  const overlapWordsArray = overlapWords.split(/\s+/);
+  const minMatchLength = Math.floor(overlapWordsArray.length * 0.6);
+  const lowerCurrentTranscript = currentTranscript.toLowerCase();
+
+  for (let startIdx = 0; startIdx < overlapWordsArray.length - minMatchLength + 1; startIdx++) {
+    const phraseToFind = overlapWordsArray.slice(startIdx, startIdx + minMatchLength).join(' ');
+    const index = lowerCurrentTranscript.indexOf(phraseToFind.toLowerCase());
+
+    if (index !== -1) {
+      const beforeMatch = lowerCurrentTranscript.substring(0, index);
+      const wordsBeforeMatch = beforeMatch.split(/\s+/).filter((w) => w.length > 0).length;
+      return wordsBeforeMatch + minMatchLength;
+    }
+  }
+  return -1;
 }
 
 /**

--- a/api/summarize.ts
+++ b/api/summarize.ts
@@ -10,9 +10,9 @@ import {
 import { chunkText, shouldUseMapReduce } from './_utils/text-chunker';
 import { requireAuth, AuthError } from './_middleware/auth';
 import { rateLimit, RateLimitError, RATE_LIMITS } from './_middleware/rate-limit';
-import { checkQuota, trackUsage } from './_middleware/usage-tracking';
+import { trackUsage } from './_middleware/usage-tracking';
 import { validatePdfFile } from './_utils/file-validator';
-import { supabaseAdmin } from './_lib/supabase-admin';
+import { resolveApiKey, FreeUserNoKeyError, QuotaExceededError } from './_utils/resolve-api-key';
 
 export const config = {
   api: {
@@ -130,29 +130,29 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     // 4. API KEY LOGIC - Tier-based enforcement
     const userProvidedKey = apiKey;
+
+    // Validate format when user provides their own key
+    if (
+      userProvidedKey &&
+      (userProvidedKey.length < MIN_API_KEY_LENGTH || userProvidedKey.length > MAX_API_KEY_LENGTH)
+    ) {
+      return res.status(400).json({ error: 'Invalid API key format' });
+    }
+
     let finalApiKey: string;
     let shouldTrackQuota = false;
 
-    if (userProvidedKey) {
-      // User provided their own API key - validate format and use it
-      if (
-        userProvidedKey.length < MIN_API_KEY_LENGTH ||
-        userProvidedKey.length > MAX_API_KEY_LENGTH
-      ) {
-        return res.status(400).json({ error: 'Invalid API key format' });
-      }
-      finalApiKey = userProvidedKey;
-      shouldTrackQuota = false; // Analytics only
-      console.log(`[Summarize] User ${userId} using own API key`);
-    } else {
-      // No user key provided - check tier
-      const { data: subscription, error: subError } = await supabaseAdmin
-        .from('subscriptions')
-        .select('tier')
-        .eq('user_id', userId)
-        .single();
-
-      if (subError || !subscription || subscription.tier === 'free') {
+    try {
+      const resolved = await resolveApiKey(
+        userId,
+        userProvidedKey || null,
+        1, // estimate 1 minute for summarization
+        'Summarize'
+      );
+      finalApiKey = resolved.apiKey;
+      shouldTrackQuota = resolved.shouldTrackQuota;
+    } catch (e) {
+      if (e instanceof FreeUserNoKeyError) {
         return res.status(403).json({
           error: 'API key required',
           message:
@@ -160,23 +160,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           upgradeUrl: '/pricing',
         });
       }
-
-      // Pro/Team user - check quota (estimate 1 minute for summarization)
-      const quotaCheck = await checkQuota(userId, 1);
-      if (!quotaCheck.allowed) {
+      if (e instanceof QuotaExceededError) {
         return res.status(429).json({
           error: 'Quota exceeded',
-          minutesRemaining: quotaCheck.minutesRemaining,
+          minutesRemaining: e.minutesRemaining,
           message: 'Insufficient quota. Please upgrade your plan or purchase additional credits.',
         });
       }
-
-      // Use platform key (OpenAI for now)
-      finalApiKey = process.env.OPENAI_API_KEY!;
-      shouldTrackQuota = true;
-      console.log(
-        `[Summarize] User ${userId} (${subscription.tier}) using platform key with quota`
-      );
+      throw e;
     }
 
     // Validate OpenRouter-specific requirements

--- a/api/transcribe.ts
+++ b/api/transcribe.ts
@@ -13,9 +13,9 @@ import type { ProcessingMode } from './_types/chunking';
 import type { JobConfiguration } from './_types/job';
 import { requireAuth, AuthError } from './_middleware/auth';
 import { rateLimit, RateLimitError, RATE_LIMITS } from './_middleware/rate-limit';
-import { checkQuota, trackUsage } from './_middleware/usage-tracking';
+import { trackUsage } from './_middleware/usage-tracking';
 import { validateAudioFile } from './_utils/file-validator';
-import { supabaseAdmin } from './_lib/supabase-admin';
+import { resolveApiKey, FreeUserNoKeyError, QuotaExceededError } from './_utils/resolve-api-key';
 
 export const config = {
   api: {
@@ -140,52 +140,34 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     // 4. API KEY LOGIC - Two-tier system (BYOK or Platform)
+    const estimatedMinutes = Math.ceil((validation.duration || 0) / 60);
     let finalApiKey: string;
     let shouldTrackQuota = false;
 
-    if (apiKey) {
-      // BYOK Mode: User provided their own API key (free tier or paid tier preference)
-      finalApiKey = apiKey;
-      shouldTrackQuota = false; // Analytics only, no quota deduction
-      console.log(`[Transcribe] User ${userId} using BYOK mode`);
-    } else {
-      // No API key provided - check if user has paid subscription
-      const { data: subscription } = await supabaseAdmin
-        .from('subscriptions')
-        .select('tier')
-        .eq('user_id', userId)
-        .single();
-
-      if (!subscription || subscription.tier === 'free') {
-        // Free user without API key - require them to configure one
+    try {
+      const resolved = await resolveApiKey(userId, apiKey, estimatedMinutes, 'Transcribe');
+      finalApiKey = resolved.apiKey;
+      shouldTrackQuota = resolved.shouldTrackQuota;
+    } catch (e) {
+      if (e instanceof FreeUserNoKeyError) {
         return res.status(403).json({
           error: 'API key required',
           message:
             'Free tier users must provide their own OpenAI API key. Configure it in Settings or upgrade to Pro.',
           upgradeUrl: '/pricing',
-          requiresApiKey: true, // Flag for frontend to show API key setup modal
+          requiresApiKey: true,
         });
       }
-
-      // Paid user (Pro/Team) - use platform key with quota tracking
-      const estimatedMinutes = Math.ceil((validation.duration || 0) / 60);
-      const quotaCheck = await checkQuota(userId, estimatedMinutes);
-
-      if (!quotaCheck.allowed) {
+      if (e instanceof QuotaExceededError) {
         return res.status(429).json({
           error: 'Quota exceeded',
-          minutesRemaining: quotaCheck.minutesRemaining,
-          minutesRequired: quotaCheck.minutesRequired,
+          minutesRemaining: e.minutesRemaining,
+          minutesRequired: e.minutesRequired,
           message: 'Insufficient quota. Please upgrade your plan or purchase additional credits.',
           upgradeUrl: '/pricing',
         });
       }
-
-      finalApiKey = process.env.OPENAI_API_KEY!;
-      shouldTrackQuota = true;
-      console.log(
-        `[Transcribe] User ${userId} (${subscription.tier}) using platform API with quota tracking`
-      );
+      throw e;
     }
 
     // Determine processing mode from performance level

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -51,26 +51,6 @@ const AuthCallbackPage = lazy(() =>
   import('../pages/AuthCallbackPage').then((module) => ({ default: module.AuthCallbackPage }))
 );
 
-// Placeholder for Configuration page (will be enhanced later)
-import { Heading, Text, GlassCard } from '@/lib';
-import { useTranslation } from 'react-i18next';
-
-function ConfigurationPlaceholder() {
-  const { t } = useTranslation();
-  return (
-    <div className="w-full max-w-[800px] mx-auto">
-      <GlassCard variant="light" className="p-8">
-        <Heading level="h1" className="mb-4">
-          {t('configPlaceholder.title')}
-        </Heading>
-        <Text variant="body" color="secondary">
-          {t('configPlaceholder.description')}
-        </Text>
-      </GlassCard>
-    </div>
-  );
-}
-
 import { PageLoader } from '@/lib/components/ui/PageLoader/PageLoader';
 
 import { migrateFromSessionStorage } from '@/utils/session-manager';
@@ -153,7 +133,7 @@ function AppRoutes() {
           {/* Dev preview route */}
           {import.meta.env.DEV && <Route path={ROUTES.PREVIEW} element={<PreviewPage />} />}
           {/* PDF Debug route */}
-          {import.meta.env.DEV && <Route path="/debug/pdf" element={<PdfPreviewPage />} />}
+          {import.meta.env.DEV && <Route path={ROUTES.DEBUG_PDF} element={<PdfPreviewPage />} />}
 
           {/* Authenticated Routes */}
           {isSignedIn ? (
@@ -166,8 +146,8 @@ function AppRoutes() {
                 {/* Audio editing route */}
                 <Route path={ROUTES.AUDIO} element={<AudioEditingPage />} />
 
-                {/* Configuration route */}
-                <Route path={ROUTES.CONFIGURE} element={<ConfigurationPlaceholder />} />
+                {/* Configuration route — redirects to home (page not yet implemented) */}
+                <Route path={ROUTES.CONFIGURE} element={<Navigate to={ROUTES.HOME} replace />} />
 
                 {/* Processing route with step checklist */}
                 <Route path={ROUTES.PROCESSING} element={<ProcessingPage />} />
@@ -185,7 +165,7 @@ function AppRoutes() {
                 <Route path={ROUTES.DOCS} element={<DocsPage />} />
 
                 {/* Pricing route */}
-                <Route path="/pricing" element={<PricingPage />} />
+                <Route path={ROUTES.PRICING} element={<PricingPage />} />
 
                 {/* Account & Billing route */}
                 <Route path={ROUTES.ACCOUNT} element={<AccountBillingPage />} />

--- a/src/features/history/components/HistoryCard.tsx
+++ b/src/features/history/components/HistoryCard.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from '@/lib/components/ui/Checkbox';
 import { useTranslation } from 'react-i18next';
 
 import type { HistorySession } from '../types/history';
+import type { ContentType } from '@/types/content-types';
 import { formatDate, formatDuration } from '../utils/formatters';
 import { ROUTES } from '@/types/routing';
 
@@ -19,12 +20,17 @@ interface HistoryCardProps {
   selectionMode?: boolean;
 }
 
-const CONTENT_TYPE_BORDER_COLOR: Record<string, string> = {
+const CONTENT_TYPE_BORDER_COLOR: Record<ContentType, string> = {
   meeting: 'var(--color-primary)',
   lecture: 'color-mix(in srgb, var(--color-primary) 70%, transparent)',
   interview: 'color-mix(in srgb, var(--color-primary) 50%, transparent)',
   podcast: 'var(--color-accent-success)',
   'voice-memo': 'var(--color-accent-warning)',
+  'sales-call': 'var(--color-primary)',
+  'medical-clinical': 'color-mix(in srgb, var(--color-accent-success) 70%, transparent)',
+  legal: 'color-mix(in srgb, var(--color-accent-warning) 70%, transparent)',
+  'daily-stand-up': 'color-mix(in srgb, var(--color-primary) 60%, transparent)',
+  'focus-group': 'color-mix(in srgb, var(--color-primary) 40%, transparent)',
   other: 'var(--color-border)',
 };
 

--- a/src/lib/components/ui/Input/Input.tsx
+++ b/src/lib/components/ui/Input/Input.tsx
@@ -81,7 +81,7 @@ export const Input: React.FC<InputProps> = ({
       {label && (
         <label
           htmlFor={inputId}
-          className="text-sm font-medium text-slate-900 dark:text-white flex items-center gap-1"
+          className="text-sm font-medium text-text-primary flex items-center gap-1"
         >
           {label}
           {props.required && <span className="text-red-500">*</span>}
@@ -91,11 +91,11 @@ export const Input: React.FC<InputProps> = ({
       <input
         id={inputId}
         className={`
-          px-4 py-3 rounded-lg border bg-white dark:bg-slate-800
-          text-slate-900 dark:text-white text-base transition-all
-          focus:outline-none focus:border-indigo-600 focus:ring-2
-          focus:ring-indigo-600/20 focus:bg-white dark:focus:bg-slate-800
-          placeholder:text-slate-400 dark:placeholder:text-slate-500
+          px-4 py-3 rounded-lg border bg-bg-surface
+          text-text-primary text-base transition-all
+          focus:outline-none focus:border-primary focus:ring-2
+          focus:ring-primary/20 focus:bg-bg-surface
+          placeholder:text-text-tertiary
           disabled:opacity-50 disabled:cursor-not-allowed
           hover:border-primary
           ${error ? 'border-accent-error focus:ring-accent-error-alpha-20' : 'border-border'}
@@ -107,7 +107,7 @@ export const Input: React.FC<InputProps> = ({
         <span className="text-xs text-red-500 animate-[slideDown_0.2s_ease-out]">{error}</span>
       )}
 
-      {hint && !error && <span className="text-xs text-slate-500 dark:text-slate-400">{hint}</span>}
+      {hint && !error && <span className="text-xs text-text-tertiary">{hint}</span>}
     </div>
   );
 };

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -584,10 +584,6 @@
     "label": "Token-Nutzung",
     "warning": "Annäherung an das tägliche Token-Limit"
   },
-  "configPlaceholder": {
-    "title": "Konfiguration",
-    "description": "KI-Anbieter-Auswahlseite - wird in Phase 3 verbessert"
-  },
   "docs": {
     "title": "Dokumentation & FAQ",
     "description": "Anleitungen und Antworten auf häufige Fragen zu Trammarise.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -583,10 +583,6 @@
     "label": "Token Usage",
     "warning": "Approaching daily token limit"
   },
-  "configPlaceholder": {
-    "title": "Configuration",
-    "description": "AI provider selection page - will be enhanced in Phase 3"
-  },
   "docs": {
     "title": "Documentation & FAQ",
     "description": "Guides and answers to common questions about Trammarise.",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -584,10 +584,6 @@
     "label": "Uso de Tokens",
     "warning": "Acercándose al límite diario de tokens"
   },
-  "configPlaceholder": {
-    "title": "Configuración",
-    "description": "Página de selección de proveedor de IA - se mejorará en Fase 3"
-  },
   "docs": {
     "title": "Documentación y Preguntas Frecuentes",
     "description": "Guías y respuestas a preguntas comunes sobre Trammarise.",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -584,10 +584,6 @@
     "label": "Utilizzo Token",
     "warning": "Avvicinamento al limite giornaliero di token"
   },
-  "configPlaceholder": {
-    "title": "Configurazione",
-    "description": "Pagina di selezione provider AI - sarà migliorata nella Fase 3"
-  },
   "docs": {
     "title": "Documentazione e FAQ",
     "description": "Guide e risposte alle domande più frequenti su Trammarise.",


### PR DESCRIPTION
## Summary

- **H1** Remove dead `ConfigurationPlaceholder` component and orphaned `configPlaceholder.*` i18n keys from all 4 locale files; `/configure/:sessionId` now redirects to home
- **H2** Extract duplicated API-key resolution (~50 lines copied across `transcribe.ts` and `summarize.ts`) into `api/_utils/resolve-api-key.ts` with typed `FreeUserNoKeyError` / `QuotaExceededError`; both callers handle each error with their own response shape
- **H3** Replace `(job.config as any)` spread in `chunk-processor.ts` with explicit `prompt` / `temperature` fields — fully type-safe, no runtime change
- **H4** Replace hardcoded `slate-*` / `indigo-*` Tailwind classes in `Input.tsx` with design tokens (`text-text-primary`, `bg-bg-surface`, `focus:border-primary`, `placeholder:text-text-tertiary`)
- **H5** Type `CONTENT_TYPE_BORDER_COLOR` as `Record<ContentType, string>` in `HistoryCard.tsx` so TypeScript catches missing entries; add all 5 missing content types
- **H6** Extract the three overlap-finding strategies from `removeOverlaps()` into named helpers (`findOverlapInSearchWindow`, `findOverlapInFullTranscript`, `findOverlapBySubstringMatch`) in `transcript-assembler.ts`

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` (frontend) — 1259 tests pass
- [x] `npm run lint` — 0 errors, 1 pre-existing warning in unmodified file
- [ ] `npm run api-test` — the Stripe checkout test failure is pre-existing (in `api/stripe/create-checkout-session.ts`, a file modified before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)