### PR TITLE
refactor(M5): replace ad-hoc error divs with Alert variant="error"

### DIFF
--- a/src/app/routes/UploadRecordPage.tsx
+++ b/src/app/routes/UploadRecordPage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import type { ContentType } from '../../types/content-types';
 import type { ProcessingMode } from '../../features/configuration/components/ProcessingModeSelector';
 import { SlidersHorizontal } from 'lucide-react';
-import { Heading, Text, GlassCard, SEO } from '@/lib';
+import { Heading, Text, GlassCard, Alert, SEO } from '@/lib';
 import { PageLayout } from '../../components/layout/PageLayout';
 import { UploadPanel } from '../../features/upload/components/UploadPanel';
 import { RecordPanel, type RecordPanelRef } from '../../features/upload/components/RecordPanel';
@@ -256,9 +256,9 @@ export function UploadRecordPage() {
 
         {/* Error Display */}
         {processingError && (
-          <div className="mt-6 p-3 rounded-lg bg-red-500/10 border border-red-500/30">
-            <Text className="text-red-600 dark:text-red-400 text-sm">{processingError}</Text>
-          </div>
+          <Alert variant="error" className="mt-6">
+            {processingError}
+          </Alert>
         )}
       </GlassCard>
 

--- a/src/features/account/components/UsagePanel/UsagePanel.tsx
+++ b/src/features/account/components/UsagePanel/UsagePanel.tsx
@@ -1,6 +1,6 @@
-// src/features/account/components/UsagePanel/UsagePanel.tsx
 import { useTranslation } from 'react-i18next';
 import { useSubscription } from '@/context/SubscriptionContext';
+import { Alert } from '@/lib/components/ui/Alert/Alert';
 import { FreePlanPanel } from './FreePlanPanel';
 import { ProPlanPanel } from './ProPlanPanel';
 
@@ -19,14 +19,7 @@ export function UsagePanel() {
   }
 
   if (error || !subscription) {
-    return (
-      <div
-        role="alert"
-        className="p-4 rounded-xl border border-accent-error/25 bg-accent-error/10 text-accent-error text-sm"
-      >
-        {t('usagePanel.error')}
-      </div>
-    );
+    return <Alert variant="error">{t('usagePanel.error')}</Alert>;
   }
 
   if (subscription.tier === 'free') {

--- a/src/features/credits/CreditPurchaseModal.tsx
+++ b/src/features/credits/CreditPurchaseModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Modal } from '../../lib/components/ui/Modal/Modal';
 import { Button } from '../../lib/components/ui/Button/Button';
 import { Badge } from '@/lib/components/ui/Badge';
+import { Alert } from '@/lib/components/ui/Alert/Alert';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js';
 
@@ -136,11 +137,7 @@ function PaymentForm({ onSuccess, onCancel }: PaymentFormProps) {
     <form onSubmit={handleSubmit} className="space-y-4">
       <PaymentElement />
 
-      {error && (
-        <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-800 dark:text-red-200 text-sm">
-          {error}
-        </div>
-      )}
+      {error && <Alert variant="error">{error}</Alert>}
 
       <div className="flex gap-3 justify-end pt-4">
         <Button variant="secondary" onClick={onCancel} disabled={processing}>
@@ -233,11 +230,7 @@ export function CreditPurchaseModal({ isOpen, onClose, onSuccess }: CreditPurcha
               Purchase additional transcription minutes for hosted API usage. Credits never expire.
             </p>
 
-            {error && (
-              <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-800 dark:text-red-200 text-sm">
-                {error}
-              </div>
-            )}
+            {error && <Alert variant="error">{error}</Alert>}
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
               {CREDIT_PACKAGES.map((pkg) => (

--- a/src/features/history/components/MigrationBanner.tsx
+++ b/src/features/history/components/MigrationBanner.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Upload, X, CheckCircle } from 'lucide-react';
 import { Button } from '@/lib/components/ui/Button';
+import { Alert } from '@/lib/components/ui/Alert/Alert';
 import { getAllSessionIds, loadSessionMetadata } from '@/utils/session-manager';
 
 interface MigrationBannerProps {
@@ -150,9 +151,9 @@ export function MigrationBanner({ onImportComplete }: MigrationBannerProps) {
           </p>
 
           {error && (
-            <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md">
-              <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-            </div>
+            <Alert variant="error" className="mb-4">
+              {error}
+            </Alert>
           )}
 
           {!imported && (

--- a/src/lib/components/ui/index.ts
+++ b/src/lib/components/ui/index.ts
@@ -77,6 +77,10 @@ export type { TooltipProps, TooltipPlacement } from './Tooltip';
 export { PricingCard } from './PricingCard';
 export type { PricingCardProps, PricingPlan } from './PricingCard';
 
+// Alert
+export { Alert } from './Alert/Alert';
+export type { AlertProps, AlertVariant } from './Alert/Alert';
+
 // Checkbox
 export { Checkbox } from './Checkbox';
 export type { CheckboxProps } from './Checkbox';


### PR DESCRIPTION
## Summary

- Exported `Alert` from the UI barrel (`src/lib/components/ui/index.ts`)
- Replaced 5 ad-hoc error `<div>` elements (all using hardcoded `red-*` or `accent-error` token classes) with `<Alert variant="error">` across 4 files:
  - `UploadRecordPage.tsx` — `bg-red-500/10 border border-red-500/30` → `<Alert variant="error">`
  - `MigrationBanner.tsx` — `bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800` → `<Alert variant="error">`
  - `UsagePanel.tsx` — manual `role="alert"` + `border-accent-error/25 bg-accent-error/10` → `<Alert variant="error">` (role="alert" is now set automatically by the component)
  - `CreditPurchaseModal.tsx` — 2 instances of `bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800` → `<Alert variant="error">`

`StorageWarning` left unchanged — it's a positioned toast with multi-severity levels and action buttons, not a simple inline error box.

## Test plan

- [x] `npm test` — 1259 frontend tests pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)