### PR TITLE
refactor: low-priority cleanup (L1, L2, L3, L6, L8)

### DIFF
--- a/api/_utils/chunk-processor.ts
+++ b/api/_utils/chunk-processor.ts
@@ -257,8 +257,3 @@ async function cleanupSubChunks(subChunks: ChunkMetadata[]): Promise<void> {
     })
   );
 }
-
-/**
- * Create a transcription function that calls OpenAI Whisper API
- */
-// createTranscribeFunction removed directly via replace_file logic; this chunk targets the removal

--- a/src/features/results/components/ResultsLayout.tsx
+++ b/src/features/results/components/ResultsLayout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react';
 
+const RESULTS_MAX_WIDTH = 'max-w-[1600px]';
+
 /**
  * Props for ResultsLayout component
  */
@@ -45,7 +47,9 @@ export function ResultsLayout({
       <div className="sticky top-0 z-40">{audioPlayer}</div>
 
       {/* Main Content: Split Panel Layout */}
-      <div className="flex-1 w-full max-w-[1600px] mx-auto p-4 lg:p-6 transition-all duration-300">
+      <div
+        className={`flex-1 w-full ${RESULTS_MAX_WIDTH} mx-auto p-4 lg:p-6 transition-all duration-300`}
+      >
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 relative items-start">
           {/* Summary Panel - 4 cols when chat open, 5 cols when chat closed */}
           <div

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -28,9 +28,24 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
   const chunksRef = useRef<Blob[]>([]);
   const timerRef = useRef<number | null>(null);
   const startTimeRef = useRef<number>(0);
+
   const durationRef = useRef<number>(0);
   const permissionStatusRef = useRef<PermissionStatus | null>(null);
   const shouldProcessResultRef = useRef<boolean>(true);
+
+  const startRecordingTimer = useCallback(
+    (recorder: MediaRecorder) => {
+      timerRef.current = window.setInterval(() => {
+        const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+        durationRef.current = elapsed;
+        setDuration(elapsed);
+        if (recorder.state === 'recording') {
+          recorder.requestData();
+        }
+      }, AUDIO_CONSTANTS.RECORDING_TIMER_INTERVAL);
+    },
+    [setDuration]
+  );
 
   // Cleanup on unmount
   useEffect(() => {
@@ -135,15 +150,7 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
       // Start timer
       startTimeRef.current = Date.now();
       durationRef.current = 0;
-      timerRef.current = window.setInterval(() => {
-        const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-        durationRef.current = elapsed;
-        setDuration(elapsed);
-        // Request data periodically for better Safari support
-        if (mediaRecorder.state === 'recording') {
-          mediaRecorder.requestData();
-        }
-      }, AUDIO_CONSTANTS.RECORDING_TIMER_INTERVAL);
+      startRecordingTimer(mediaRecorder);
 
       return true; // Success
     } catch (err) {
@@ -153,7 +160,7 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
       setError('Microphone access denied. Please grant permission in your browser settings.');
       return false; // Failure
     }
-  }, []);
+  }, [startRecordingTimer]);
 
   const pauseRecording = useCallback(() => {
     if (mediaRecorderRef.current?.state === 'recording') {
@@ -176,16 +183,9 @@ export const useAudioRecorder = (): UseAudioRecorderReturn => {
       // Resume timer using the ref value
       const pausedDuration = durationRef.current;
       startTimeRef.current = Date.now() - pausedDuration * 1000;
-      timerRef.current = window.setInterval(() => {
-        const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-        durationRef.current = elapsed;
-        setDuration(elapsed);
-        if (mediaRecorderRef.current?.state === 'recording') {
-          mediaRecorderRef.current.requestData();
-        }
-      }, AUDIO_CONSTANTS.RECORDING_TIMER_INTERVAL);
+      startRecordingTimer(mediaRecorderRef.current);
     }
-  }, []);
+  }, [startRecordingTimer]);
 
   const stopRecording = useCallback(() => {
     if (

--- a/src/repositories/SessionRepository.ts
+++ b/src/repositories/SessionRepository.ts
@@ -147,7 +147,7 @@ export class SessionRepository {
       .select()
       .single();
 
-    if (error) throw new Error('Failed to create session');
+    if (error) throw new Error(`Failed to create session: ${error.message}`);
     return fromDbRow(row as Record<string, unknown>);
   }
 
@@ -163,7 +163,7 @@ export class SessionRepository {
       .select()
       .single();
 
-    if (error) throw new Error('Failed to upsert session');
+    if (error) throw new Error(`Failed to upsert session ${data.sessionId}: ${error.message}`);
     return fromDbRow(row as Record<string, unknown>);
   }
 
@@ -179,7 +179,7 @@ export class SessionRepository {
       .is('deleted_at', null)
       .maybeSingle();
 
-    if (error) throw new Error('Failed to fetch session');
+    if (error) throw new Error(`Failed to fetch session ${sessionId}: ${error.message}`);
     if (!row) return null;
     return fromDbRow(row as Record<string, unknown>);
   }
@@ -209,7 +209,7 @@ export class SessionRepository {
       .select()
       .single();
 
-    if (error) throw new Error('Failed to update session');
+    if (error) throw new Error(`Failed to update session ${sessionId}: ${error.message}`);
     return fromDbRow(row as Record<string, unknown>);
   }
 
@@ -224,7 +224,7 @@ export class SessionRepository {
       .update(softDelete)
       .eq('session_id', sessionId);
 
-    if (error) throw new Error('Failed to delete session');
+    if (error) throw new Error(`Failed to delete session ${sessionId}: ${error.message}`);
   }
 
   /**
@@ -244,7 +244,7 @@ export class SessionRepository {
       .order('created_at', { ascending: false })
       .range(offset, offset + limit - 1);
 
-    if (error) throw new Error('Failed to fetch sessions');
+    if (error) throw new Error(`Failed to fetch sessions: ${error.message}`);
     return {
       sessions: (rows ?? []).map((r) => fromDbRow(r as Record<string, unknown>)),
       total: count ?? 0,

--- a/src/utils/session-manager.ts
+++ b/src/utils/session-manager.ts
@@ -21,7 +21,7 @@ const SESSION_KEY_PREFIX = 'trammarise_session_';
  * This ensures stable File references across loadSession() calls,
  * preventing unnecessary useEffect cleanup/re-initialization in hooks.
  */
-const audioFileCache = new Map<string, { blob: Blob; file: File }>();
+const sessionAudioBlobCache = new Map<string, { blob: Blob; file: File }>();
 
 /**
  * Generate a unique session ID
@@ -163,7 +163,7 @@ export async function loadSession(sessionId: string): Promise<SessionData | null
     const audioFileRecord = await loadAudioFile(sessionId);
     if (audioFileRecord) {
       // Check cache to avoid creating new File objects for same blob
-      let cached = audioFileCache.get(sessionId);
+      let cached = sessionAudioBlobCache.get(sessionId);
 
       // Only create new File if blob has changed or not cached
       if (!cached || cached.blob !== audioFileRecord.audioBlob) {
@@ -171,7 +171,7 @@ export async function loadSession(sessionId: string): Promise<SessionData | null
           type: audioFileRecord.audioBlob.type,
         });
         cached = { blob: audioFileRecord.audioBlob, file };
-        audioFileCache.set(sessionId, cached);
+        sessionAudioBlobCache.set(sessionId, cached);
       }
 
       session.audioFile = {
@@ -204,7 +204,7 @@ export async function loadSession(sessionId: string): Promise<SessionData | null
 export async function deleteSession(sessionId: string): Promise<void> {
   try {
     // Clear cache entry to prevent memory leaks
-    audioFileCache.delete(sessionId);
+    sessionAudioBlobCache.delete(sessionId);
 
     // Remove from localStorage and IndexedDB
     localStorage.removeItem(getSessionKey(sessionId));
@@ -251,7 +251,7 @@ export function getAllSessionIds(): string[] {
  */
 export async function clearAllSessions(): Promise<void> {
   // Clear entire cache
-  audioFileCache.clear();
+  sessionAudioBlobCache.clear();
 
   const sessionIds = getAllSessionIds();
   await Promise.all(sessionIds.map(deleteSession));


### PR DESCRIPTION
## Summary

- **L1**: Remove orphaned dead comment in `chunk-processor.ts` (referenced a function deleted long ago)
- **L2**: Extract `startRecordingTimer` helper in `useAudioRecorder.ts` — eliminates ~10-line duplicated interval setup between `startRecording` and `resumeRecording`
- **L3**: Add session ID and `error.message` context to all 6 `throw` statements in `SessionRepository.ts`
- **L6**: Rename `audioFileCache` → `sessionAudioBlobCache` in `session-manager.ts` (the map holds Blobs, not Audio objects)
- **L8**: Extract `RESULTS_MAX_WIDTH` constant in `ResultsLayout.tsx` (was magic `max-w-[1600px]` inline)

Skipped:
- L4: `getPublicUrl` never returns an error (builds URL locally — no async call)
- L5: `ThemeContext` export is needed by `useTheme.ts`; moving hook into the context file triggers `react-refresh/only-export-components`
- L7: AssemblyAI provider has no `validateApiKey` method — nothing to align with OpenAI/OpenRouter